### PR TITLE
Omnibus

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -21,7 +21,7 @@ path = [
   "dotfiles/config/yamllint/config",
   "dprint.json",
 ]
-SPDX-FileCopyrightText = "2024 Keith Maxwell <keith.maxwell@gmail.com>"
+SPDX-FileCopyrightText = "2025 Keith Maxwell <keith.maxwell@gmail.com>"
 SPDX-License-Identifier = "CC0-1.0"
 
 [[annotations]]
@@ -37,8 +37,8 @@ path = [
   "dotfiles/local/bin/vimj",
   "dotfiles/local/bin/vinfo",
 ]
-SPDX-FileCopyrightText = "2024 Keith Maxwell <keith.maxwell@gmail.com>"
+SPDX-FileCopyrightText = "2025 Keith Maxwell <keith.maxwell@gmail.com>"
 SPDX-License-Identifier = "MPL-2.0"
 
-# SPDX-FileCopyrightText: 2024 Keith Maxwell <keith.maxwell@gmail.com>
+# SPDX-FileCopyrightText: 2025 Keith Maxwell <keith.maxwell@gmail.com>
 # SPDX-License-Identifier: CC0-1.0

--- a/config.toml
+++ b/config.toml
@@ -9,6 +9,10 @@ force_chmod = true
 src = "zshrc"
 dst = "~/.zshrc"
 
+[dotfiles.f_zshenv]
+src = "zshenv"
+dst = "~/.zshenv"
+
 [dotfiles.f_tmux]
 src = "tmux.conf"
 dst = "~/.tmux.conf"

--- a/dotfiles/zshenv
+++ b/dotfiles/zshenv
@@ -1,0 +1,6 @@
+# shellcheck shell=sh disable=SC1090,SC1091,SC1094
+#
+# .zshenv
+# Copyright 2025 Keith Maxwell
+# SPDX-License-Identifier: MPL-2.0
+#

--- a/dotfiles/zshenv
+++ b/dotfiles/zshenv
@@ -1,6 +1,31 @@
-# shellcheck shell=sh disable=SC1090,SC1091,SC1094
+# Environment variables for ZSH
+#
+# Store environment variables that only affect an interactive shell in
+# `~/.zshrc`.
+export ANSIBLE_COLLECTIONS_PATH="$HOME/.ansible/collections:/usr/lib/python3.12/site-packages/ansible_collections/"
+export DOTDROP_PROFILE=default
+for i in \
+  "$HOME/.local/bin" \
+  "$HOME/.deno/bin" \
+  "$HOME/.zvm/bin" \
+  "$HOME/.cargo/bin" \
+  ;
+do
+    if ! test -d "$i" ; then continue ; fi
+    case "$PATH" in
+      *"$i"*) true ;;
+      # On macOS the order of prefixies in PATH may be changed by path_helper.
+      # Below, if append is chosen instead of prepend, then the order will be
+      # unchanged. However it is then not possible to override binaries from
+      # system package. This file is more likely used on Linux so prepend is
+      # chosen.
+      *) export PATH="$i:$PATH" ;;
+    esac
+done
+unset i
 #
 # .zshenv
 # Copyright 2025 Keith Maxwell
 # SPDX-License-Identifier: MPL-2.0
 #
+# shellcheck shell=sh disable=SC1090,SC1091,SC1094

--- a/dotfiles/zshrc
+++ b/dotfiles/zshrc
@@ -6,10 +6,10 @@
 # Copyright 2025 Keith Maxwell
 # SPDX-License-Identifier: MPL-2.0
 #
-bindkey -v
+bindkey -v  # vi mode, see man zshzle
 setopt interactive_comments
 FPATH="$FPATH:$HOME/.local/share/zsh/site-functions"
-# Command line completion {{{1
+# Files for command line completion {{{1
 # these files must be generated before the compinit commands
 site="$HOME/.local/share/zsh/site-functions"
 executable="$HOME/.local/share/uv/tools/nox/bin/register-python-argcomplete"
@@ -27,25 +27,40 @@ fi
 unset executable site #}}}1
 autoload -U compinit && compinit
 autoload -U bashcompinit && bashcompinit  # for nox above
-# Aliases and <80 character functions {{{1
+# Aliases {{{1
 alias cp="cp -i"  # To avoid accidentally over-writing content
 alias mv="mv -i"  # "
 alias rm="rm -i"  # To avoid accidentally deleting content
 alias ls="ls --color=auto --group-directories-first"
 alias lc="tig --reverse remotes/origin/HEAD.."
-
-lfcd () { cd "$(command lf -print-last-dir "$@")" || return ; }
-ywd() { printf '%s' "$PWD"  | sed "s,^$HOME,~," | ygg ; printf '\n' ; }
+# Functions for use as commands {{{1
+# <80 characters, alphabetically sorted {{{
 gcd() { cd "$(git rev-parse --show-toplevel)" || return ; }
+lfcd () { cd "$(command lf -print-last-dir "$@")" || return ; }
+ywd() { printf '%s' "$PWD" | sed "s,^$HOME,~," | ygg ; printf '\n' ; }
 yz() { fc -l -n 0- | fzf --tac | osc52.sh ; }
 # }}}
-bindkey -M vicmd v edit-command-line  #{{{1
+motd() { #{{{
+  : > /run/motd && systemctl --user restart uncommitted && cat /run/motd
+} #}}}
+yy() { # {{{
+  if [ ! -t 0 ] ; then
+    tail -n 1
+  else
+    fc -ln -1
+  fi | tr -d '\n' | ygg ; >&2 printf '\n'
+} # }}}
+# }}}
+# Editing command lines {{{1
+bindkey -M vicmd v edit-command-line
 autoload edit-command-line
 zle -N edit-command-line
-bindkey -M viins '^o' execute-named-cmd #{{{1
+bindkey -M viins '^o' execute-named-cmd #{{{
 # using `escape` then `:` causes the result of `execute-named-cmd` to be
 # inserted before the last character of the existing line
-if [ -f /usr/share/fzf/shell/key-bindings.zsh ] ; then  #{{{1
+# }}}
+# FZF key bindings {{{
+if [ -f /usr/share/fzf/shell/key-bindings.zsh ] ; then
   # load binding for ctrl-r ^r
   . /usr/share/fzf/shell/key-bindings.zsh
   # prefer ctrl-e to alt-c
@@ -56,11 +71,9 @@ if [ -f /usr/share/fzf/shell/key-bindings.zsh ] ; then  #{{{1
   # ctrl-t is hidden by new tab
   bindkey -M vicmd -r '^T'
   bindkey -M viins -r '^T'
-fi
-motd() { #{{{1
-  : > /run/motd && systemctl --user restart uncommitted && cat /run/motd
-} #}}}1
-zshrc_fzf_fzf() { #{{{1
+fi #}}}
+# Ctrl-f to present an fzf menu of fzf menus {{{
+zshrc_fzf_fzf() {
   cmd=$( fzf<<EOF
 git status --short | fzf --multi | cut -c4-
 find | fzf --multi
@@ -80,7 +93,9 @@ EOF
 zle -N zshrc_fzf_fzf
 bindkey _M viins '^f' zshrc_fzf_fzf
 bindkey _M vicmd '^f' zshrc_fzf_fzf
-zshrc_tig() { #{{{1
+# }}}
+# Ctrl-p to select a git commit hash with tig {{{
+zshrc_tig() {
   # relies on the following in config_home/tig/config
   # bind refs <Ctrl-g> <sh -c "echo %(refname) >/tmp/tig-output"
   # bind generic <Ctrl-g> <sh -c "echo %(commit) >/tmp/tig-output"
@@ -105,6 +120,7 @@ zshrc_tig() { #{{{1
 zle -N zshrc_tig
 bindkey _M viins '^p' zshrc_tig
 bindkey _M vicmd '^p' zshrc_tig
+#}}}
 zmodload zsh/complist
 zshrc_menu_select() { zle expand-or-complete; zle menu-select ; }
 zle -N zshrc_menu_select
@@ -115,15 +131,8 @@ bindkey -M menuselect l vi-forward-char
 bindkey -M menuselect h vi-backward-char
 bindkey -M menuselect '^[' undo
 bindkey -M menuselect '^I' accept-and-hold  # ^I = Tab
-yy() { # {{{1
-  if [ ! -t 0 ] ; then
-    tail -n 1
-  else
-    fc -ln -1
-  fi | tr -d '\n' | ygg ; >&2 printf '\n'
-} # }}}1
+# }}}1
 # Environment variables for interactive shells {{{1
-#
 # Store environment variables that affect all shells in `~/.zshenv`.
 if [ -x /usr/bin/vim ]; then
   export EDITOR=vim

--- a/dotfiles/zshrc
+++ b/dotfiles/zshrc
@@ -187,8 +187,6 @@ if [ -f "$HOME/.zsh/spaceship/spaceship.zsh" ] && [ -z "$SPACESHIP_DISABLE" ] ; 
       char          # Prompt character
     )
     SPACESHIP_HOST_SHOW=always
-    SPACESHIP_HOST_COLOR=black
-    SPACESHIP_HOST_COLOR_SSH=black
     SPACESHIP_PROMPT_PREFIXES_SHOW=false
     SPACESHIP_EXIT_CODE_SHOW=true
     SPACESHIP_GIT_BRANCH_PREFIX="🪵 "

--- a/dotfiles/zshrc
+++ b/dotfiles/zshrc
@@ -3,7 +3,7 @@
 #    For portability use POSIX compatible shell script syntax where possible
 #
 # .zshrc
-# Copyright 2023 Keith Maxwell
+# Copyright 2025 Keith Maxwell
 # SPDX-License-Identifier: MPL-2.0
 #
 bindkey -v

--- a/dotfiles/zshrc
+++ b/dotfiles/zshrc
@@ -156,14 +156,9 @@ if pager --version >/dev/null 2>&1 ; then export PAGER=pager ; fi
 # https://chromium.googlesource.com/apps/libapps/+/master/nassh/doc/FAQ.md#Why-do-curses-apps-display-x_q_etc_instead-of-and-and-other-graphics
 export NCURSES_NO_UTF8_ACS=1
 # }}}1
-# PS1 if spaceship is not installed {{{1
-if [ -n "$TMUX" ] ; then
-  PS1="%? ⁅%23<<%d⁆%# "
-else
-  PS1="%? [%23<<%d]%# "
-fi
 # }}}1
-# https://spaceship-prompt.sh {{{1
+# Prompt — PS1 {{{1
+# https://spaceship-prompt.sh
 if [ -f "$HOME/.zsh/spaceship/spaceship.zsh" ] && [ -z "$SPACESHIP_DISABLE" ] ; then
   spaceship_tmux() {  # show a computer inside tmux
     tmux_status=""
@@ -199,7 +194,12 @@ if [ -f "$HOME/.zsh/spaceship/spaceship.zsh" ] && [ -z "$SPACESHIP_DISABLE" ] ; 
     SPACESHIP_VENV_COLOR=207
   }
   . "$HOME/.zsh/spaceship/spaceship.zsh"
-fi #}}}1
+elif [ -n "$TMUX" ] ; then
+  PS1="%? ⁅%23<<%d⁆%# "
+else
+  PS1="%? [%23<<%d]%# "
+fi
+# }}}
 if [ -s /run/motd ]; then cat /run/motd ; fi
 if [ -f ~/.zshrc.local ]; then . ~/.zshrc.local ; fi # late so that PS1 & spaceship can be overridden
 # vim: set foldmethod=marker foldlevel=0 filetype=sh :

--- a/dotfiles/zshrc
+++ b/dotfiles/zshrc
@@ -103,6 +103,8 @@ zshrc_tig() { #{{{1
   return $ret
 }
 zle -N zshrc_tig
+bindkey _M viins '^p' zshrc_tig
+bindkey _M vicmd '^p' zshrc_tig
 zmodload zsh/complist
 zshrc_menu_select() { zle expand-or-complete; zle menu-select ; }
 zle -N zshrc_menu_select

--- a/dotfiles/zshrc
+++ b/dotfiles/zshrc
@@ -122,9 +122,9 @@ yy() { # {{{1
     fc -ln -1
   fi | tr -d '\n' | ygg ; >&2 printf '\n'
 } # }}}1
-# Environment variables {{{1
-export ANSIBLE_COLLECTIONS_PATH="$HOME/.ansible/collections:/usr/lib/python3.12/site-packages/ansible_collections/"
-export DOTDROP_PROFILE=default
+# Environment variables for interactive shells {{{1
+#
+# Store environment variables that affect all shells in `~/.zshenv`.
 if [ -x /usr/bin/vim ]; then
   export EDITOR=vim
 else
@@ -132,30 +132,10 @@ else
 fi
 export FCEDIT=$EDITOR
 export READNULLCMD=cat  # more is the default
-for i in \
-  "$HOME/.local/bin" \
-  "$HOME/.deno/bin" \
-  "$HOME/.zvm/bin" \
-  "$HOME/.cargo/bin" \
-  ;
-do
-    if ! test -d "$i" ; then continue ; fi
-    case "$PATH" in
-      *"$i"*) true ;;
-      # On macOS the order of prefixies in PATH may be changed by path_helper.
-      # Below, if append is chosen instead of prepend, then the order will be
-      # unchanged. However it is then not possible to override binaries from
-      # system package. This file is more likely used on Linux so prepend is
-      # chosen.
-      *) export PATH="$i:$PATH" ;;
-    esac
-done
-unset i
 if fzf --version >/dev/null 2>&1 ; then export FZF_DEFAULT_OPTS='--height=10 --bind=ctrl-a:select-all' ; fi
 if pager --version >/dev/null 2>&1 ; then export PAGER=pager ; fi
 # https://chromium.googlesource.com/apps/libapps/+/master/nassh/doc/FAQ.md#Why-do-curses-apps-display-x_q_etc_instead-of-and-and-other-graphics
 export NCURSES_NO_UTF8_ACS=1
-# }}}1
 # }}}1
 # Prompt — PS1 {{{1
 # https://spaceship-prompt.sh

--- a/dotlocalslashbin.py
+++ b/dotlocalslashbin.py
@@ -8,7 +8,12 @@
 # ///
 """Download and extract files to `~/.local/bin/`."""
 import tarfile
-from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, Namespace
+from argparse import (
+    ArgumentDefaultsHelpFormatter,
+    ArgumentParser,
+    BooleanOptionalAction,
+    Namespace,
+)
 from dataclasses import dataclass
 from enum import Enum
 from hashlib import file_digest
@@ -23,7 +28,7 @@ from urllib.request import urlopen
 from zipfile import ZipFile
 
 
-__version__ = "0.0.12"
+__version__ = "0.0.15"
 
 _HOME = str(Path("~").expanduser())
 _OUTPUT = Path("~/.local/bin/")
@@ -33,7 +38,7 @@ _SHA512_LENGTH = 128
 class _CustomNamespace(Namespace):
     output: Path
     input: Path
-    downloaded: Path
+    cache: Path
 
 
 Action = Enum("Action", ["command", "copy", "symlink", "untar", "unzip"])
@@ -59,6 +64,10 @@ def main() -> int:
     """Parse command line arguments and download each file."""
     args = _parse_args()
 
+    if args.clear:
+        for path in args.cache.expanduser().iterdir():
+            path.unlink()
+
     with args.input.expanduser().open("rb") as file:
         data = load(file)
 
@@ -80,7 +89,7 @@ def main() -> int:
             item.action = _guess_action(item)
 
         if item.url.startswith("https://"):
-            item.downloaded = args.downloaded.expanduser() / item.url.rsplit("/", 1)[1]
+            item.downloaded = args.cache.expanduser() / item.url.rsplit("/", 1)[1]
         else:
             item.downloaded = Path(item.url)
         try:
@@ -142,9 +151,16 @@ def _parse_args() -> _CustomNamespace:
     parser.add_argument("--input", default="bin.toml", help=help_, type=Path)
     help_ = "Target directory"
     parser.add_argument("--output", default=_OUTPUT, help=help_, type=Path)
-    help_ = "Output directory"
+    help_ = "Cache directory"
     default = "~/.cache/dotlocalslashbin/"
-    parser.add_argument("--downloaded", default=default, help=help_, type=Path)
+    parser.add_argument("--cache", default=default, help=help_, type=Path)
+    help_ = "Clear the cache directory first"
+    parser.add_argument(
+        "--clear",
+        default=False,
+        action=BooleanOptionalAction,
+        help=help_,
+    )
     return parser.parse_args(namespace=_CustomNamespace())
 
 

--- a/vendor.toml
+++ b/vendor.toml
@@ -1,0 +1,18 @@
+# File to update the vendored version of dotlocalslashbin.py
+#
+# Use this file with:
+#
+#     uv tool run dotlocalslashbin --input=vendor.toml --output=.
+#
+["dotlocalslashbin.py"]
+# Update the url and hash below from the output of:
+#
+#     uv tool run qypi files dotlocalslashbin
+#
+url = "https://files.pythonhosted.org/packages/95/c3/66bd6e4938c8834bb5601358c3d7bca2576f5c149ab2970dd1ebd1316487/dotlocalslashbin-0.0.12-py2.py3-none-any.whl"
+expected = "b420076d4f1dc693e92c6c1a524fb9c3a83b768eba8f25ae16585a7d655a9e10"
+action = "unzip"
+version = "--version"
+#
+# SPDX-FileCopyrightText: 2025 Keith Maxwell <keith.maxwell@gmail.com>
+# SPDX-License-Identifier: CC0-1.0

--- a/vendor.toml
+++ b/vendor.toml
@@ -9,8 +9,8 @@
 #
 #     uv tool run qypi files dotlocalslashbin
 #
-url = "https://files.pythonhosted.org/packages/95/c3/66bd6e4938c8834bb5601358c3d7bca2576f5c149ab2970dd1ebd1316487/dotlocalslashbin-0.0.12-py2.py3-none-any.whl"
-expected = "b420076d4f1dc693e92c6c1a524fb9c3a83b768eba8f25ae16585a7d655a9e10"
+url = "https:////files.pythonhosted.org/packages/10/b0/d2bd4bb65ef9a4ae668286d0c9e9b713f4f3d64d7c2c7708f6fa5b82eabd/dotlocalslashbin-0.0.15-py2.py3-none-any.whl"
+expected = "4b94d19d686df555c0390d34dbcadf2b74ca48f805c5d0f97adc746db96ef1dc"
 action = "unzip"
 version = "--version"
 #


### PR DESCRIPTION
- **chore: update copyright years**
- **feat: add a file to keep dotlocalslashbin.py up to date**
- **chore: update to dotlocalslashbin==0.0.15**
- **feat: rely on default host colors**
- **fix: restore binding for `zshrc_tig`**
- **refactor: prompt setup**
- **refactor: start to use a separate .zshenv**
- **feat: move important environment variables to .zshenv**
- **docs: reorganise and improve comments in .zshrc**
