### PR TITLE
fix: improve portability of check for pager

### DIFF
--- a/dotfiles/zshenv
+++ b/dotfiles/zshenv
@@ -17,7 +17,7 @@ do
       # On macOS the order of prefixies in PATH may be changed by path_helper.
       # Below, if append is chosen instead of prepend, then the order will be
       # unchanged. However it is then not possible to override binaries from
-      # system package. This file is more likely used on Linux so prepend is
+      # system packages. This file is more likely used on Linux so prepend is
       # chosen.
       *) export PATH="$i:$PATH" ;;
     esac

--- a/dotfiles/zshrc
+++ b/dotfiles/zshrc
@@ -140,7 +140,7 @@ fi
 export FCEDIT=$EDITOR
 export READNULLCMD=cat  # more is the default
 if fzf --version >/dev/null 2>&1 ; then export FZF_DEFAULT_OPTS='--height=10 --bind=ctrl-a:select-all' ; fi
-if pager --version >/dev/null 2>&1 ; then export PAGER=pager ; fi
+if command -v pager >/dev/null ; then export PAGER=pager ; fi
 # https://chromium.googlesource.com/apps/libapps/+/master/nassh/doc/FAQ.md#Why-do-curses-apps-display-x_q_etc_instead-of-and-and-other-graphics
 export NCURSES_NO_UTF8_ACS=1
 # }}}1


### PR DESCRIPTION
`command -v` is part of POSIX. Not all versions of `cat` support `--version`.
