### PR TITLE
Streamline workstation configuration

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,14 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        # https://github.com/renovatebot/renovate/blob/main/package.json#L141
-        with: { node-version: "^22.13.0" }
-      - run: |-
-          node --version \
-          && npm --version \
-          && npm exec --yes --package renovate -- renovate --version
-      - run: npm exec --yes --package renovate -- renovate-config-validator
       - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6
         with: { enable-cache: false }
       - run: ./noxfile.py
@@ -30,3 +22,6 @@ jobs:
       - run: incus exec c1 -- su --login maxwell-k < .README.md-files/02.sh
       - run: incus exec c1 -- su --login maxwell-k < .README.md-files/04.sh
       - run: ./.README.md-files/cleanup.sh
+  renovate-config-validator:
+    # yamllint disable-line rule:line-length
+    uses: maxwell-k/dotlocalslashbin/.github/workflows/renovate.yaml@a33ce13bfa55aac3dbc6658478e1e91c55003020 # v0.0.18

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -26,7 +26,8 @@
       "matchStrings": [
         "https:[/][/]github[.]com[/](?<depName>.+?)[/]releases[/]download[/](?<currentValue>.+?)[/]"
       ],
-      "datasourceTemplate": "github-releases"
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "{{#if (containsString currentValue '.0')}}loose{{else}}semver-coerced{{/if}}"
     },
     {
       "customType": "regex",

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -38,7 +38,7 @@
         "https:[/][/]raw.githubusercontent[.]com[/](?<depName>.+?)[/]refs/tags[/](?<currentValue>.+?)[/]"
       ],
       "datasourceTemplate": "github-tags",
-      "versioningTemplate": "regex:^nassh-(?<major>\\d+)[.](?<minor>\\d+)$"
+      "versioningTemplate": "{{#if (containsString depName 'libapps')}}regex:^nassh-(?<major>\\d+)[.](?<minor>\\d+){{else}}semver-coerced{{/if}}$"
     },
     {
       "customType": "regex",

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -32,6 +32,17 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
+        "/^[[:alnum:]-]+.toml$/"
+      ],
+      "matchStrings": [
+        "https:[/][/]raw.githubusercontent[.]com[/](?<depName>.+?)[/]refs/tags[/](?<currentValue>.+?)[/]"
+      ],
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "regex:^nassh-(?<major>\\d+)[.](?<minor>\\d+)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
         "README.md",
         ".README.md-files/02.sh"
       ],

--- a/dotfiles/local/bin/tomlv.py
+++ b/dotfiles/local/bin/tomlv.py
@@ -31,16 +31,16 @@ __version__ = "0.0.1"
 def error(toml: str) -> tuple[int, int, str] | None:
     r"""Return (line, column, message) for invalid TOML.
 
-    >>> _error("") is None
+    >>> error("") is None
     True
 
-    >>> _error("example =")
+    >>> error("example =")
     (1, 9, 'Invalid value')
 
-    >>> _error("x =\n")
-    (1, 3, 'Invalid value')
+    >>> error("x =\n")
+    (1, 4, 'Invalid value')
 
-    >>> _error('example = ["1"\n"2"]')
+    >>> error('example = ["1"\n"2"]')
     (2, 1, 'Unclosed array')
 
     """

--- a/github.toml
+++ b/github.toml
@@ -3,13 +3,13 @@
 url = "https://raw.githubusercontent.com/git/git/master/contrib/git-jump/git-jump"
 
 ["osc52.sh"]
-url = "https://raw.githubusercontent.com/libapps/libapps-mirror/master/hterm/etc/osc52.sh"
+url = "https://raw.githubusercontent.com/libapps/libapps-mirror/refs/tags/nassh-0.67/hterm/etc/osc52.sh"
 
 ["hterm-notify.sh"]
-url = "https://raw.githubusercontent.com/libapps/libapps-mirror/master/hterm/etc/hterm-notify.sh"
+url = "https://raw.githubusercontent.com/libapps/libapps-mirror/refs/tags/nassh-0.67/hterm/etc/hterm-notify.sh"
 
 ["hterm-show-file.sh"]
-url = "https://raw.githubusercontent.com/libapps/libapps-mirror/master/hterm/etc/hterm-show-file.sh"
+url = "https://raw.githubusercontent.com/libapps/libapps-mirror/refs/tags/nassh-0.67/hterm/etc/hterm-show-file.sh"
 
 [wcurl]
 url = "https://github.com/curl/wcurl/releases/download/v2025.04.20/wcurl"

--- a/github.toml
+++ b/github.toml
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S uv tool run dotlocalslashbin --input
 [git-jump]
-url = "https://raw.githubusercontent.com/git/git/master/contrib/git-jump/git-jump"
+url = "https://raw.githubusercontent.com/git/git/refs/tags/v2.50.0/contrib/git-jump/git-jump"
 
 ["osc52.sh"]
 url = "https://raw.githubusercontent.com/libapps/libapps-mirror/refs/tags/nassh-0.67/hterm/etc/osc52.sh"

--- a/github.toml
+++ b/github.toml
@@ -11,6 +11,9 @@ url = "https://raw.githubusercontent.com/libapps/libapps-mirror/master/hterm/etc
 ["hterm-show-file.sh"]
 url = "https://raw.githubusercontent.com/libapps/libapps-mirror/master/hterm/etc/hterm-show-file.sh"
 
+[wcurl]
+url = "https://github.com/curl/wcurl/releases/download/v2025.04.20/wcurl"
+
 # github.toml
 # Copyright Keith Maxwell
 # SPDX-License-Identifier: CC0-1.0

--- a/github.toml
+++ b/github.toml
@@ -1,3 +1,4 @@
+#!/usr/bin/env -S uv tool run dotlocalslashbin --input
 [git-jump]
 url = "https://raw.githubusercontent.com/git/git/master/contrib/git-jump/git-jump"
 

--- a/linux-amd64.toml
+++ b/linux-amd64.toml
@@ -1,3 +1,4 @@
+#!/usr/bin/env -S uv tool run dotlocalslashbin --input
 [a4]
 url = "https://github.com/maxwell-k/a4/releases/download/0.2.0/a4"
 expected = "a15420c22fd67b2a31e54467c63a0dec8e060ee59b5005d9a66896c207672591" # ./update.py a4

--- a/linux-amd64.toml
+++ b/linux-amd64.toml
@@ -7,8 +7,8 @@ modifier = "SHA256SUMS"
 
 [actionlint]
 url = "https://github.com/rhysd/actionlint/releases/download/v1.7.7/actionlint_1.7.7_linux_amd64.tar.gz"
-#      https://github.com/rhysd/actionlint/releases/download/v1.7.7/actionlint_1.7.7_checksums.txt
-expected = "023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757"
+expected = "023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757" # ./update.py actionlint
+modifier = "_checksums.txt"
 ignore = [
   "LICENSE.txt",
   "README.md",

--- a/linux-amd64.toml
+++ b/linux-amd64.toml
@@ -44,6 +44,12 @@ prefix = "uv-x86_64-unknown-linux-gnu/"
 ignore = ["uv-x86_64-unknown-linux-gnu"]
 modifier = ".sha256"
 
+[fnm]
+# <https://github.com/Schniz/fnm/releases>, no checksums provided
+url = "https://github.com/Schniz/fnm/releases/download/v1.38.1/fnm-linux.zip"
+version = "--version"
+expected = "b69e5c9a05c1e17e4a7de9a17df14ba430d049f2591af791a6f850a170296069"
+
 # linux-amd64.toml
 # Copyright Keith Maxwell
 # SPDX-License-Identifier: CC0-1.0

--- a/linux-amd64.toml
+++ b/linux-amd64.toml
@@ -1,7 +1,6 @@
 [a4]
 url = "https://github.com/maxwell-k/a4/releases/download/0.2.0/a4"
-# https://github.com/maxwell-k/a4/releases/download/0.2.0/SHA256SUMS
-expected = "a15420c22fd67b2a31e54467c63a0dec8e060ee59b5005d9a66896c207672591"
+expected = "a15420c22fd67b2a31e54467c63a0dec8e060ee59b5005d9a66896c207672591" # ./update.py a4
 version = "--version"
 modifier = "SHA256SUMS"
 

--- a/linux-amd64.toml
+++ b/linux-amd64.toml
@@ -50,6 +50,13 @@ url = "https://github.com/Schniz/fnm/releases/download/v1.38.1/fnm-linux.zip"
 version = "--version"
 expected = "b69e5c9a05c1e17e4a7de9a17df14ba430d049f2591af791a6f850a170296069"
 
+[tofu]
+url = "https://github.com/opentofu/opentofu/releases/download/v1.8.6/tofu_1.8.6_linux_amd64.zip"
+modifier = "_SHA256SUMS"
+expected = "4714768d1c502cd3a67ad8925cea44280e1c732ff005fcf1ee006530441cf667"
+ignore = ["LICENSE", "README.md", "CHANGELOG.md"]
+version = "version"
+
 # linux-amd64.toml
 # Copyright Keith Maxwell
 # SPDX-License-Identifier: CC0-1.0

--- a/linux-amd64.toml
+++ b/linux-amd64.toml
@@ -57,6 +57,12 @@ expected = "4714768d1c502cd3a67ad8925cea44280e1c732ff005fcf1ee006530441cf667" # 
 ignore = ["LICENSE", "README.md", "CHANGELOG.md"]
 version = "version"
 
+[yq]
+url = "https://github.com/mikefarah/yq/releases/download/v4.45.4/yq_linux_amd64"
+version = "--version"
+expected = "b96de04645707e14a12f52c37e6266832e03c29e95b9b139cddcae7314466e69" # ./update.py yq
+modifier = "checksums-bsd"
+
 # linux-amd64.toml
 # Copyright Keith Maxwell
 # SPDX-License-Identifier: CC0-1.0

--- a/linux-amd64.toml
+++ b/linux-amd64.toml
@@ -53,7 +53,7 @@ expected = "b69e5c9a05c1e17e4a7de9a17df14ba430d049f2591af791a6f850a170296069"
 [tofu]
 url = "https://github.com/opentofu/opentofu/releases/download/v1.8.6/tofu_1.8.6_linux_amd64.zip"
 modifier = "_SHA256SUMS"
-expected = "4714768d1c502cd3a67ad8925cea44280e1c732ff005fcf1ee006530441cf667"
+expected = "4714768d1c502cd3a67ad8925cea44280e1c732ff005fcf1ee006530441cf667" # ./update.py tofu
 ignore = ["LICENSE", "README.md", "CHANGELOG.md"]
 version = "version"
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -85,5 +85,16 @@ def vendor(session: Session) -> None:
         session.run(*cmd.split(" "))
 
 
+@nox.session()
+def doctest(session: Session) -> None:
+    """Run all doctests in this repository."""
+    for i in [
+        "update.py",
+        "dotfiles/local/bin/vimj.py",
+        "dotfiles/local/bin/tomlv.py",
+    ]:
+        session.run("python", "-m", "doctest", "-v", i)
+
+
 if __name__ == "__main__":
     nox.main()

--- a/noxfile.py
+++ b/noxfile.py
@@ -61,6 +61,7 @@ def embedme(session: Session) -> None:
     session.run(*cmd.split(" "))
 
 
+@nox.session(python=False)
 def usort(session: Session) -> None:
     """Check imports are sorted in all Python files."""
     files = session.run("git", "ls-files", "*.py", silent=True)

--- a/unrecognised.py
+++ b/unrecognised.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Check for unrecognised files in ~/.local/bin/."""
+from pathlib import Path
+from tomllib import load
+
+TARGET = Path("~/.local/bin/").expanduser()
+TOML_INPUTS = [
+    "bin.toml",
+    "github.toml",
+    "linux-amd64.toml",
+]
+
+
+def main() -> None:
+    """Check for unrecognised files in ~/.local/bin/."""
+    toml = set()
+    for toml_input in TOML_INPUTS:
+        with Path(toml_input).open("rb") as file:
+            toml |= set(load(file).keys())
+    unrecognised = set(TARGET.iterdir())
+    # if pulumi is in toml, then recognise pulumi-language-python and others
+    unrecognised -= {i for i in unrecognised if any(i.name.startswith(j) for j in toml)}
+    links = {i for i in unrecognised if i.is_symlink()}
+    unrecognised -= {i for i in links if "uv" in i.readlink().parts}
+    unrecognised -= {i for i in links if "dotfiles" in i.readlink().parts}
+    for i in unrecognised:
+        if i.name == "__pycache__":
+            continue
+        if not i.is_file():
+            msg = f"{i} is not a file."
+            raise ValueError(msg)
+        try:
+            text = i.read_text()
+        except UnicodeDecodeError:
+            text = "\n\n"
+        if text.splitlines()[1].startswith("exec npm exec"):
+            # wrappers around npm exec installed in vimfiles
+            continue
+        print(i)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+# unrecognised.py
+# SPDX-License-Identifier: MPL-2.0
+# Copyright Keith Maxwell 2025

--- a/update.py
+++ b/update.py
@@ -30,7 +30,7 @@ def _parse_args(arg_list: list[str] | None) -> Namespace:
 
 
 def _apply_modifier(url: str, modifier: str) -> str:
-    """Calculate the URL for the checksums from the URL using a modifier.
+    """Apply a modifier to the file URL to get the checksum URL.
 
     >>> _apply_modifier("https://example.org/file-1.1.1.zip", "SHA256SUMS")
     'https://example.org/SHA256SUMS'
@@ -43,9 +43,9 @@ def _apply_modifier(url: str, modifier: str) -> str:
     'https://example.org/file_1.2.3_checksums.txt'
     """
     filename = url[url.rindex("/") + 1 :]
-    if url.endswith("_linux_amd64.tar.gz"):
-        url = url.removesuffix("_linux_amd64.tar.gz")
-    elif not modifier.startswith("."):
+    for suffix in ["_linux_amd64.tar.gz"]:
+        url = url.removesuffix(suffix)
+    if modifier.startswith("SHA256SUMS"):
         url = url.removesuffix(filename)
     url += modifier
     return url

--- a/update.py
+++ b/update.py
@@ -37,9 +37,15 @@ def _apply_modifier(url: str, modifier: str) -> str:
 
     >>> _apply_modifier("https://example.org/file-1.1.1.zip", ".sha256")
     'https://example.org/file-1.1.1.zip.sha256'
+
+    >>> url = "https://example.org/file_1.2.3_linux_amd64.tar.gz"
+    >>> _apply_modifier(url, "_checksums.txt")
+    'https://example.org/file_1.2.3_checksums.txt'
     """
     filename = url[url.rindex("/") + 1 :]
-    if not modifier.startswith("."):
+    if url.endswith("_linux_amd64.tar.gz"):
+        url = url.removesuffix("_linux_amd64.tar.gz")
+    elif not modifier.startswith("."):
         url = url.removesuffix(filename)
     url += modifier
     return url
@@ -56,6 +62,7 @@ def _update(target: Path, key: str) -> None:
     except KeyError:
         print(f"{key} does not have `modifier` specified")
         return
+    filename = url[url.rindex("/") + 1 :]
     url = _apply_modifier(url, modifier)
     try:
         with urlopen(url) as response:
@@ -63,7 +70,6 @@ def _update(target: Path, key: str) -> None:
     except HTTPError as error:
         print(f"{url} responded with status code {error.status}")
         return
-    filename = url[url.rindex("/") + 1 :]
     line = next(i for i in content.splitlines() if filename in i)
     new = line.split()[0]
 

--- a/update.py
+++ b/update.py
@@ -41,9 +41,13 @@ def _apply_modifier(url: str, modifier: str) -> str:
     >>> url = "https://example.org/file_1.2.3_linux_amd64.tar.gz"
     >>> _apply_modifier(url, "_checksums.txt")
     'https://example.org/file_1.2.3_checksums.txt'
+
+    >>> url = "https://example.org/file_1.2.3_linux_amd64.zip"
+    >>> _apply_modifier(url, "_checksums.txt")
+    'https://example.org/file_1.2.3_checksums.txt'
     """
     filename = url[url.rindex("/") + 1 :]
-    for suffix in ["_linux_amd64.tar.gz"]:
+    for suffix in ["_linux_amd64.tar.gz", "_linux_amd64.zip"]:
         url = url.removesuffix(suffix)
     if modifier.startswith("SHA256SUMS"):
         url = url.removesuffix(filename)

--- a/update.py
+++ b/update.py
@@ -11,7 +11,12 @@ from tomllib import load
 from urllib.request import HTTPError, urlopen
 
 
-def _parse_args(arg_list: list[str] | None) -> Namespace:
+def parse_args(arg_list: list[str] | None) -> Namespace:
+    """Parse command line arguments.
+
+    >>> parse_args([])
+    Namespace(key=None, target=PosixPath('linux-amd64.toml'))
+    """
     parser = ArgumentParser()
     parser.add_argument(
         "key",
@@ -29,30 +34,70 @@ def _parse_args(arg_list: list[str] | None) -> Namespace:
     return parser.parse_args(arg_list)
 
 
-def _apply_modifier(url: str, modifier: str) -> str:
+def apply_modifier(url: str, modifier: str) -> str:
     """Apply a modifier to the file URL to get the checksum URL.
 
-    >>> _apply_modifier("https://example.org/file-1.1.1.zip", "SHA256SUMS")
+    >>> apply_modifier("https://example.org/file-1.1.1.zip", "SHA256SUMS")
     'https://example.org/SHA256SUMS'
 
-    >>> _apply_modifier("https://example.org/file-1.1.1.zip", ".sha256")
+    >>> apply_modifier("https://example.org/file-1.1.1.zip", "checksums-bsd")
+    'https://example.org/checksums-bsd'
+
+    >>> apply_modifier("https://example.org/file-1.1.1.zip", ".sha256")
     'https://example.org/file-1.1.1.zip.sha256'
 
     >>> url = "https://example.org/file_1.2.3_linux_amd64.tar.gz"
-    >>> _apply_modifier(url, "_checksums.txt")
+    >>> apply_modifier(url, "_checksums.txt")
     'https://example.org/file_1.2.3_checksums.txt'
 
     >>> url = "https://example.org/file_1.2.3_linux_amd64.zip"
-    >>> _apply_modifier(url, "_checksums.txt")
+    >>> apply_modifier(url, "_checksums.txt")
     'https://example.org/file_1.2.3_checksums.txt'
     """
     filename = url[url.rindex("/") + 1 :]
     for suffix in ["_linux_amd64.tar.gz", "_linux_amd64.zip"]:
         url = url.removesuffix(suffix)
-    if modifier.startswith("SHA256SUMS"):
+    if modifier[0] != ".":
         url = url.removesuffix(filename)
     url += modifier
     return url
+
+
+def extract(text: str, filename: str) -> str:
+    r"""Extract the hash for filename from text.
+
+    Handles output from `sha256sum`:
+
+    >>> text = "a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447  file"
+    >>> extract(text, "file")
+    'a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447'
+
+    Handles output from `sha256sum --tag`:
+
+    >>> text = "SHA256 (file) = "
+    >>> text += "a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447\n"
+    >>> extract(text, "file")
+    'a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447'
+
+    Handles output from `rhash -r -a --bsd` see https://github.com/rhash/RHash:
+
+    >>> text = "SHA256 (file.zip) = "
+    >>> text += "0000000000000000000000000000000000000000000000000000000000000000\n"
+    >>> text += "CRC32 (file) = af083b2d\n"
+    >>> text += "SHA256 (file) = "
+    >>> text += "a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447\n"
+    >>> extract(text, "file")
+    'a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447'
+    """
+    lines = text.splitlines()
+    if "=" in lines[0]:
+        marker = f"({filename})"
+        line = next(i for i in lines if marker in i and i.startswith("SHA256"))
+        result = line.split()[3]
+    else:
+        line = next(i for i in lines if filename in i)
+        result = line.split()[0]
+    return result
 
 
 def _update(target: Path, key: str) -> None:
@@ -67,15 +112,14 @@ def _update(target: Path, key: str) -> None:
         print(f"{key} does not have `modifier` specified")
         return
     filename = url[url.rindex("/") + 1 :]
-    url = _apply_modifier(url, modifier)
+    url = apply_modifier(url, modifier)
     try:
         with urlopen(url) as response:
-            content = response.read().decode()
+            text = response.read().decode()
     except HTTPError as error:
         print(f"{url} responded with status code {error.status}")
         return
-    line = next(i for i in content.splitlines() if filename in i)
-    new = line.split()[0]
+    new = extract(text, filename)
 
     text = target.read_text().replace(old, new)
     target.write_text(text)
@@ -83,7 +127,7 @@ def _update(target: Path, key: str) -> None:
 
 def main(arg_list: list[str] | None = None) -> int:
     """Update each expected field using a modifier field and a GET request."""
-    args = _parse_args(arg_list)
+    args = parse_args(arg_list)
     if args.key:
         _update(args.target, args.key)
         return 0


### PR DESCRIPTION
- **chore: reuse renovate job from dotlocalslashbin**
- **docs: a4 is supported by update.py**
- **tests: add doctests to update.py**
- **feat: make github.toml executable**
- **feat: make linux-amd64.toml executable**
- **feat: support actionlint in update.py**
- **feat: add fnm (again)**
- **feat: add wcurl**
- **feat: add opentofu**
- **feat: version hterm scripts**
- **feat: version git-jump**
- **refactor: update.py**
- **feat: add support for tofu to update.py**
- **feat: add yq**
- **fix: add missing decorator to usort session**
- **feat: run doctests in CI**
- **fix: doctests in tomlv**
- **feat: add the unrecognised script**
