### PR TITLE
Migrate functionality to vimfiles

### DIFF
--- a/bin/dotdrop.toml
+++ b/bin/dotdrop.toml
@@ -18,55 +18,45 @@ dst = "~/.tmux.conf"
 [dotfiles.f_ygg]
 src = "local/bin/ygg"
 dst = "~/.local/bin/ygg"
-chmod = "755"
 
 [dotfiles.f_percollate]
 src = "local/bin/percollate"
 dst = "~/.local/bin/percollate"
-chmod = "755"
 
 [dotfiles.f_prettier]
 src = "local/bin/prettier"
 dst = "~/.local/bin/prettier"
-chmod = "755"
 link = "nolink"
 
 [dotfiles.f_vinfo]
 src = "local/bin/vinfo"
 dst = "~/.local/bin/vinfo"
-chmod = "755"
 
 [dotfiles.f_jsonlint]
 src = "local/bin/jsonlint"
 dst = "~/.local/bin/jsonlint"
-chmod = "755"
 link = "nolink"
 
 [dotfiles.f_gtree]
 src = "local/bin/gtree"
 dst = "~/.local/bin/gtree"
-chmod = "755"
 
 [dotfiles.f_pyright-langserver]
 src = "local/bin/pyright-langserver"
 dst = "~/.local/bin/pyright-langserver"
-chmod = "755"
 link = "nolink"
 
 [dotfiles.f_pdf-information]
 src = "local/bin/pdf-information.py"
 dst = "~/.local/bin/pdf-information.py"
-chmod = "755"
 
 [dotfiles.f_mvslugify]
 src = "local/bin/mvslugify"
 dst = "~/.local/bin/mvslugify"
-chmod = "755"
 
 [dotfiles.f_mvh1]
 src = "local/bin/mvh1.py"
 dst = "~/.local/bin/mvh1"
-chmod = "755"
 
 [dotfiles.f_lfrc]
 src = "config/lf/lfrc"

--- a/bin/dotdrop.toml
+++ b/bin/dotdrop.toml
@@ -23,28 +23,13 @@ dst = "~/.local/bin/ygg"
 src = "local/bin/percollate"
 dst = "~/.local/bin/percollate"
 
-[dotfiles.f_prettier]
-src = "local/bin/prettier"
-dst = "~/.local/bin/prettier"
-link = "nolink"
-
 [dotfiles.f_vinfo]
 src = "local/bin/vinfo"
 dst = "~/.local/bin/vinfo"
 
-[dotfiles.f_jsonlint]
-src = "local/bin/jsonlint"
-dst = "~/.local/bin/jsonlint"
-link = "nolink"
-
 [dotfiles.f_gtree]
 src = "local/bin/gtree"
 dst = "~/.local/bin/gtree"
-
-[dotfiles.f_pyright-langserver]
-src = "local/bin/pyright-langserver"
-dst = "~/.local/bin/pyright-langserver"
-link = "nolink"
 
 [dotfiles.f_pdf-information]
 src = "local/bin/pdf-information.py"

--- a/bin/unrecognised.py
+++ b/bin/unrecognised.py
@@ -23,6 +23,7 @@ def main() -> None:
     links = {i for i in unrecognised if i.is_symlink()}
     unrecognised -= {i for i in links if "uv" in i.readlink().parts}
     unrecognised -= {i for i in links if "dotfiles" in i.readlink().parts}
+    unrecognised -= {i for i in links if ".vim" in i.readlink().parts}
     for i in unrecognised:
         if i.name == "__pycache__":
             continue

--- a/local/bin/vinfo
+++ b/local/bin/vinfo
@@ -1,9 +1,0 @@
-#!/bin/sh
-# local/bin/vinfo
-# Copyright 2025 Keith Maxwell
-# SPDX-License-Identifier: MPL-2.0
-if ! info --version >/dev/null 2>&1 ; then
-  printf '"info" not found; "info" is required for "vinfo".\n'
-else
-  exec vim "+packadd vinfo" "+Vinfo ${1}" "+only"
-fi


### PR DESCRIPTION
- **Remove unnecessary file permissions**
- **Remove tools that are installed in ~/.vim**
- **unrecognised.py ignores .vim links as well**
- **Migrate vinfo to vimfiles**
