### PR TITLE
Add receipt.py; tweak reference.py and adf

### DIFF
--- a/bin/install.py
+++ b/bin/install.py
@@ -47,6 +47,7 @@ SPECIFICATIONS: list[tuple[str] | tuple[str, str]] = [
     ("~/.local/bin/pdf-information.py",),
     ("~/.local/bin/percollate",),
     ("~/.local/bin/podcast-to-dropbox.py",),
+    ("~/.local/bin/receipt.py",),
     ("~/.local/bin/reference.py",),
     ("~/.local/bin/repositories.py",),
     ("~/.local/bin/venv.py",),

--- a/local/bin/adf
+++ b/local/bin/adf
@@ -59,7 +59,7 @@ EXAMPLES
 
 	Scan multiple pages single sided:
 
-		adf full example.pdf '--source=Automatic Document Feeder(left aligned)'
+		adf full example.pdf '--source=Automatic Document Feeder(center aligned)'
 
 	Scan a very faint single-side:
 

--- a/local/bin/adf
+++ b/local/bin/adf
@@ -63,14 +63,22 @@ EXAMPLES
 
 	Scan a very faint single-side:
 
-		adf acquire --mode "True Gray" --batch-count=1
-		mv adf.0001.pbm original
-		magick original -threshold 90% adf.0001.pbm
-		adf encode example.pdf
+		adf acquire --mode "True Gray" --batch-count=1 \\
+		&& mv adf.0001.pbm original \\
+		&& magick original -threshold 90% adf.0001.pbm \\
+		&& adf encode example.pdf
 
 	Scan a receipt:
 
 		adf full example.pdf --AutoDocumentSize=yes --batch-count=1
+	
+	Scan a landscape page:
+
+		adf acquire --batch-count=1 \\
+		&& mv adf.0001.pbm original \\
+		&& magick original -rotate 90 adf.0001.pbm \\
+		&& adf encode example.pdf
+
 EOF
   exit "${1:-1}"
 }

--- a/local/bin/receipt.py
+++ b/local/bin/receipt.py
@@ -28,7 +28,7 @@ from doctest import ELLIPSIS, testmod
 from os import environ
 from pathlib import Path
 from shlex import join
-from subprocess import run
+from subprocess import DEVNULL, Popen, run
 from textwrap import dedent
 
 import cv2
@@ -37,6 +37,8 @@ import numpy as np
 
 DPI = 300
 SCANIMAGE = "/usr/bin/scanimage"
+VIEWER = "/usr/bin/google-chrome-stable"
+EXCLUDED = {".jp2"}
 BLANK = 250
 ENVRC = {"SANE_CONFIG_DIR": str(Path("~/.config/adf").expanduser())}
 CACHE = Path("cache.pnm")
@@ -105,8 +107,18 @@ def main(_args: list[str] | None = None) -> int:
     img = img[:, left : int(left + width)]
 
     write(args.output, img)
+    view(args.output)
 
     return 0
+
+
+def view(name: str) -> None:
+    """Open a file in viewier."""
+    path = Path(name)
+    if path.suffix in EXCLUDED:
+        return
+    cmd = (VIEWER, path.absolute())
+    Popen(cmd, stdout=DEVNULL, stderr=DEVNULL)
 
 
 def write(name: str, img: np.ndarray) -> None:

--- a/local/bin/receipt.py
+++ b/local/bin/receipt.py
@@ -39,6 +39,7 @@ DPI = 300
 SCANIMAGE = "/usr/bin/scanimage"
 VIEWER = "/usr/bin/google-chrome-stable"
 EXCLUDED = {".jp2"}
+BORDER = 10
 BLANK = 250
 ENVRC = {"SANE_CONFIG_DIR": str(Path("~/.config/adf").expanduser())}
 CACHE = Path("cache.pnm")
@@ -104,8 +105,8 @@ def main(_args: list[str] | None = None) -> int:
         img = cv2.warpAffine(img, rotation, size, flags=cv2.INTER_CUBIC)
 
         (centre, _), (_, width), _ = rect
-        left = int(centre - width / 2)
-        img = img[:, left : int(left + width)]
+        left = int(centre - width / 2 - BORDER)
+        img = img[:, left : int(left + width + 2 * BORDER)]
 
     write(args.output, img, args.compression)
     view(args.output)

--- a/local/bin/receipt.py
+++ b/local/bin/receipt.py
@@ -106,7 +106,7 @@ def main(_args: list[str] | None = None) -> int:
     left = int(centre - width / 2)
     img = img[:, left : int(left + width)]
 
-    write(args.output, img)
+    write(args.output, img, args.compression)
     view(args.output)
 
     return 0
@@ -121,11 +121,11 @@ def view(name: str) -> None:
     Popen(cmd, stdout=DEVNULL, stderr=DEVNULL)
 
 
-def write(name: str, img: np.ndarray) -> None:
+def write(name: str, img: np.ndarray, compression: int = 20) -> None:
     """Write an image to a file."""
     path = Path(name)
     if path.suffix.lower() == ".pdf":
-        params = [cv2.IMWRITE_JPEG2000_COMPRESSION_X1000, 20]
+        params = [cv2.IMWRITE_JPEG2000_COMPRESSION_X1000, compression]
         success, encoded = cv2.imencode(".jp2", img, params)
         if not success:
             msg = "JPEG 2000 encoding failed."
@@ -163,8 +163,12 @@ def parse_args(args: list[str] | None) -> Namespace:
 
     >>> parse_args(['output.pnm']).output
     'output.pnm'
+
     >>> parse_args(['output.pnm'])
-    Namespace(... options=[], debug=False, keep=False, test=False)
+    Namespace(... options=[], debug=False, keep=False, compression=20, test=False)
+
+    >>> parse_args(['output.pnm', "--compression=10"])
+    Namespace(... options=[], debug=False, keep=False, compression=10, test=False)
 
     >>> args = parse_args(['--debug', 'example.pdf'])
     >>> args.debug, args.keep
@@ -205,6 +209,12 @@ def parse_args(args: list[str] | None) -> Namespace:
         "--keep",
         action="store_true",
         help=f"keep '{CACHE}'.",
+    )
+    parser.add_argument(
+        "--compression",
+        default=20,
+        type=int,
+        help="target compression ratio 1 to 1,000.",
     )
     parser.add_argument(
         "--test",

--- a/local/bin/receipt.py
+++ b/local/bin/receipt.py
@@ -24,7 +24,7 @@ Process means:
 
 import logging
 from argparse import ArgumentParser, Namespace, RawDescriptionHelpFormatter
-from doctest import ELLIPSIS, testmod
+from doctest import testmod
 from os import environ
 from pathlib import Path
 from shlex import join
@@ -55,7 +55,7 @@ def main(_args: list[str] | None = None) -> int:
     logger.debug("command line arguments: %s", args)
 
     if args.test:
-        results = testmod(optionflags=ELLIPSIS)
+        results = testmod()
         logger.info("test results: %s", results)
         return max(0, min(results.failed, 1))
 
@@ -163,18 +163,26 @@ def error_if_scanner_missing(name: str, env: dict[str, str]) -> None:
 def parse_args(args: list[str] | None) -> Namespace:
     """Parse command line arguments.
 
-    >>> parse_args(['output.pnm']).output
+    Check the simplest case:
+
+    >>> args = parse_args(['output.pnm'])
+    >>> args.output
     'output.pnm'
+    >>> args.options, args.debug, args.keep, args.compression, args.test
+    ([], False, False, 20, False)
 
-    >>> parse_args(['output.pnm'])
-    Namespace(... options=[], debug=False, keep=False, compression=20, test=False)
+    Check that compression is parsed as an integer:
 
-    >>> parse_args(['output.pnm', "--compression=10"])
-    Namespace(... options=[], debug=False, keep=False, compression=10, test=False)
+    >>> parse_args(['output.pnm', "--compression=10"]).compression
+    10
+
+    Check that setting --debug implies --keep:
 
     >>> args = parse_args(['--debug', 'example.pdf'])
     >>> args.debug, args.keep
     (True, True)
+
+    Check that options for scanimage can be parsed:
 
     >>> parse_args(['example.pdf', '--', '-x100']).options
     ['-x100']

--- a/local/bin/receipt.py
+++ b/local/bin/receipt.py
@@ -91,20 +91,21 @@ def main(_args: list[str] | None = None) -> int:
     if args.debug:
         write("debug0.png", img)
 
-    contour = largest(img)
-    if args.debug:
-        debug = cv2.cvtColor(img, cv2.COLOR_GRAY2BGR)
-        cv2.drawContours(debug, [contour], -1, (0, 0, 255), 2)
-        write("debug1.png", debug)
+    if not any("-x" in i for i in args.options):
+        contour = largest(img)
+        if args.debug:
+            debug = cv2.cvtColor(img, cv2.COLOR_GRAY2BGR)
+            cv2.drawContours(debug, [contour], -1, (0, 0, 255), 2)
+            write("debug1.png", debug)
 
-    rect = cv2.minAreaRect(contour)
-    rotation = cv2.getRotationMatrix2D(rect[0], rect[-1] + 90.0, 1.0)
-    size = (img.shape[1], img.shape[0])
-    img = cv2.warpAffine(img, rotation, size, flags=cv2.INTER_CUBIC)
+        rect = cv2.minAreaRect(contour)
+        rotation = cv2.getRotationMatrix2D(rect[0], rect[-1] + 90.0, 1.0)
+        size = (img.shape[1], img.shape[0])
+        img = cv2.warpAffine(img, rotation, size, flags=cv2.INTER_CUBIC)
 
-    (centre, _), (_, width), _ = rect
-    left = int(centre - width / 2)
-    img = img[:, left : int(left + width)]
+        (centre, _), (_, width), _ = rect
+        left = int(centre - width / 2)
+        img = img[:, left : int(left + width)]
 
     write(args.output, img, args.compression)
     view(args.output)

--- a/local/bin/receipt.py
+++ b/local/bin/receipt.py
@@ -113,7 +113,8 @@ def write(name: str, img: np.ndarray) -> None:
     """Write an image to a file."""
     path = Path(name)
     if path.suffix.lower() == ".pdf":
-        success, encoded = cv2.imencode(".jp2", img)
+        params = [cv2.IMWRITE_JPEG2000_COMPRESSION_X1000, 20]
+        success, encoded = cv2.imencode(".jp2", img, params)
         if not success:
             msg = "JPEG 2000 encoding failed."
             raise RuntimeError(msg)

--- a/local/bin/receipt.py
+++ b/local/bin/receipt.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env -S uv run
+"""Scan a receipt, process it, save a PDF."""
+
+# /// script
+# dependencies = [
+#   "numpy",
+#   "opencv-python",
+# ]
+# requires-python = ">=3.13"
+# ///
+
+from os import environ
+from pathlib import Path
+from subprocess import run
+
+import cv2
+import numpy as np
+
+SCANIMAGE = "/usr/bin/scanimage"
+TRAILER_THRESHOLD = 250
+ENVRC = {"SANE_CONFIG_DIR": str(Path("~/.config/adf").expanduser())}
+CMD = (
+    SCANIMAGE,
+    "--format=pnm",
+    "--resolution=300",
+    "--mode=True Gray",
+    "--source=Automatic Document Feeder(center aligned)",
+)
+
+
+def _largest(img: np.ndarray) -> np.ndarray:
+    blur = cv2.GaussianBlur(img, (5, 5), 0)
+    _, thresh = cv2.threshold(blur, 200, 255, cv2.THRESH_BINARY)
+    kernel = np.ones((5, 5), np.uint8)
+    thresh = cv2.morphologyEx(thresh, cv2.MORPH_CLOSE, kernel)
+    contours, _ = cv2.findContours(thresh, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    return sorted(contours, key=cv2.contourArea, reverse=True)[0]
+
+
+def _main() -> int:
+    env = environ.copy()
+    env.update(ENVRC)
+
+    result = run((SCANIMAGE, "-L"), capture_output=True, check=True, env=env)
+    if b"brother5" not in result.stdout:
+        msg = "brother5 scanner not found"
+        raise RuntimeError(msg)
+
+    cache = Path("cache.pnm")
+    if cache.is_file():
+        scan = cache.read_bytes()
+    else:
+        result = run(CMD, capture_output=True, check=True, env=env)
+        scan = result.stdout
+        cache.write_bytes(scan)
+
+    img = cv2.imdecode(np.frombuffer(scan, np.uint8), cv2.IMREAD_GRAYSCALE)
+    if img is None:
+        msg = "Failed to read image from standard input."
+        raise RuntimeError(msg)
+
+    # crop trailer
+    keep = ~(np.all(img >= TRAILER_THRESHOLD, axis=1))
+    img = img[keep, :]
+
+    # deskew
+    rect = cv2.minAreaRect(_largest(img))
+    rotation = cv2.getRotationMatrix2D(rect[0], rect[-1] + 90.0, 1.0)
+    size = (img.shape[1], img.shape[0])
+    img = cv2.warpAffine(img, rotation, size, flags=cv2.INTER_CUBIC)
+
+    # crop the sides
+    (centre, _), (_, width), _ = rect
+    left = int(centre - width / 2)
+    right = int(left + width)
+    img = img[:, left:right]
+
+    cv2.imwrite("output.png", img)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/local/bin/receipt.py
+++ b/local/bin/receipt.py
@@ -1,34 +1,132 @@
 #!/usr/bin/env -S uv run
-"""Scan a receipt, process it, save a PDF."""
+"""Scan a receipt, process it and save as a PDF.
+
+Process means:
+
+1. remove a trailing blank block
+2. detect a rectangle
+3. rotate so the rectangle is vertical and
+4. crop to the width of the rectangle.
+"""
 
 # /// script
 # dependencies = [
+#   "img2pdf",
 #   "numpy",
 #   "opencv-python",
 # ]
 # requires-python = ">=3.13"
 # ///
 
+# local/bin/receipt.py
+# Copyright 2026 Keith Maxwell
+# SPDX-License-Identifier: MPL-2.0
+
+import logging
+from argparse import ArgumentParser, Namespace, RawDescriptionHelpFormatter
+from doctest import ELLIPSIS, testmod
 from os import environ
 from pathlib import Path
+from shlex import join
 from subprocess import run
+from textwrap import dedent
 
 import cv2
+import img2pdf
 import numpy as np
 
+DPI = 300
 SCANIMAGE = "/usr/bin/scanimage"
-TRAILER_THRESHOLD = 250
+BLANK = 250
 ENVRC = {"SANE_CONFIG_DIR": str(Path("~/.config/adf").expanduser())}
-CMD = (
-    SCANIMAGE,
-    "--format=pnm",
-    "--resolution=300",
-    "--mode=True Gray",
-    "--source=Automatic Document Feeder(center aligned)",
-)
+CACHE = Path("cache.pnm")
+
+logger = logging.getLogger(__name__)
 
 
-def _largest(img: np.ndarray) -> np.ndarray:
+def main(_args: list[str] | None = None) -> int:
+    """Scan a receipt, process it and save as a PDF."""
+    args = parse_args(_args)
+
+    setup_logging(debug=args.debug)
+    logger.debug("command line arguments: %s", args)
+
+    if args.test:
+        results = testmod(optionflags=ELLIPSIS)
+        logger.info("test results: %s", results)
+        return max(0, min(results.failed, 1))
+
+    env = environ.copy()
+    env.update(ENVRC)
+
+    if CACHE.is_file():
+        logger.debug("%s exists, using cached scan", CACHE)
+        scan = CACHE.read_bytes()
+    else:
+        error_if_scanner_missing("brother5", env)
+        cmd = (
+            SCANIMAGE,
+            "--format=pnm",
+            f"--resolution={DPI}",
+            "--mode=True Gray",
+            "--source=Automatic Document Feeder(center aligned)",
+            *args.options,
+        )
+        result = run(cmd, capture_output=True, check=True, env=env)
+        logger.debug("returncode %s from `%s`", result.returncode, join(cmd))
+        scan = result.stdout
+
+    img = cv2.imdecode(np.frombuffer(scan, np.uint8), cv2.IMREAD_GRAYSCALE)
+    if img is None:
+        msg = "Failed to read image from scanner."
+        raise RuntimeError(msg)
+
+    if args.keep and not CACHE.is_file():
+        write("cache.pnm", img)
+
+    stop = img.shape[0] - np.argmax(np.any(img[::-1] < BLANK, axis=1))
+    img = img[:stop, :]
+    if args.debug:
+        write("debug0.png", img)
+
+    contour = largest(img)
+    if args.debug:
+        debug = cv2.cvtColor(img, cv2.COLOR_GRAY2BGR)
+        cv2.drawContours(debug, [contour], -1, (0, 0, 255), 2)
+        write("debug1.png", debug)
+
+    rect = cv2.minAreaRect(contour)
+    rotation = cv2.getRotationMatrix2D(rect[0], rect[-1] + 90.0, 1.0)
+    size = (img.shape[1], img.shape[0])
+    img = cv2.warpAffine(img, rotation, size, flags=cv2.INTER_CUBIC)
+
+    (centre, _), (_, width), _ = rect
+    left = int(centre - width / 2)
+    img = img[:, left : int(left + width)]
+
+    write(args.output, img)
+
+    return 0
+
+
+def write(name: str, img: np.ndarray) -> None:
+    """Write an image to a file."""
+    path = Path(name)
+    if path.suffix.lower() == ".pdf":
+        success, encoded = cv2.imencode(".jp2", img)
+        if not success:
+            msg = "JPEG 2000 encoding failed."
+            raise RuntimeError(msg)
+        img2pdf.default_dpi = DPI
+        with path.open("wb") as outputstream:
+            img2pdf.convert(encoded.tobytes(), outputstream=outputstream)
+    else:
+        cv2.imwrite(name, img)
+    logger.debug("wrote %s", name)
+
+
+def largest(img: np.ndarray) -> np.ndarray:
+    """Return the largest contour."""
     blur = cv2.GaussianBlur(img, (5, 5), 0)
     _, thresh = cv2.threshold(blur, 200, 255, cv2.THRESH_BINARY)
     kernel = np.ones((5, 5), np.uint8)
@@ -37,48 +135,85 @@ def _largest(img: np.ndarray) -> np.ndarray:
     return sorted(contours, key=cv2.contourArea, reverse=True)[0]
 
 
-def _main() -> int:
-    env = environ.copy()
-    env.update(ENVRC)
-
-    result = run((SCANIMAGE, "-L"), capture_output=True, check=True, env=env)
-    if b"brother5" not in result.stdout:
-        msg = "brother5 scanner not found"
+def error_if_scanner_missing(name: str, env: dict[str, str]) -> None:
+    """Raise a RuntimeError if the named scanner is not present."""
+    cmd = (SCANIMAGE, "-L")
+    result = run(cmd, capture_output=True, check=True, env=env)
+    logger.debug("standard output from `%s`: %s", join(cmd), result.stdout)
+    if name.encode() not in result.stdout:
+        msg = f"scanner {name} not found"
         raise RuntimeError(msg)
 
-    cache = Path("cache.pnm")
-    if cache.is_file():
-        scan = cache.read_bytes()
-    else:
-        result = run(CMD, capture_output=True, check=True, env=env)
-        scan = result.stdout
-        cache.write_bytes(scan)
 
-    img = cv2.imdecode(np.frombuffer(scan, np.uint8), cv2.IMREAD_GRAYSCALE)
-    if img is None:
-        msg = "Failed to read image from standard input."
-        raise RuntimeError(msg)
+def parse_args(args: list[str] | None) -> Namespace:
+    """Parse command line arguments.
 
-    # crop trailer
-    keep = ~(np.all(img >= TRAILER_THRESHOLD, axis=1))
-    img = img[keep, :]
+    >>> parse_args(['output.pnm']).output
+    'output.pnm'
+    >>> parse_args(['output.pnm'])
+    Namespace(... options=[], debug=False, keep=False, test=False)
 
-    # deskew
-    rect = cv2.minAreaRect(_largest(img))
-    rotation = cv2.getRotationMatrix2D(rect[0], rect[-1] + 90.0, 1.0)
-    size = (img.shape[1], img.shape[0])
-    img = cv2.warpAffine(img, rotation, size, flags=cv2.INTER_CUBIC)
+    >>> args = parse_args(['--debug', 'example.pdf'])
+    >>> args.debug, args.keep
+    (True, True)
 
-    # crop the sides
-    (centre, _), (_, width), _ = rect
-    left = int(centre - width / 2)
-    right = int(left + width)
-    img = img[:, left:right]
+    >>> parse_args(['example.pdf', '--', '-x100']).options
+    ['-x100']
+    """
+    name = Path(__file__).name
+    epilog = dedent(f"""
+    If the automatic width detection fails specify the width manually, for
+    example:
 
-    cv2.imwrite("output.png", img)
+        {name} output.pdf -- -x100
 
-    return 0
+    """)
+    parser = ArgumentParser(
+        description=__doc__,
+        epilog=epilog,
+        formatter_class=RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "output",
+        nargs="?",
+        help="output file name",
+    )
+    parser.add_argument(
+        "options",
+        nargs="*",
+        help="additional options to pass to scanimage.",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="show debug logging.",
+    )
+    parser.add_argument(
+        "--keep",
+        action="store_true",
+        help=f"keep '{CACHE}'.",
+    )
+    parser.add_argument(
+        "--test",
+        action="store_true",
+        help="run doctest against this file.",
+    )
+    parsed = parser.parse_args(args)
+    if parsed.debug:
+        parsed.keep = True
+    if parsed.output is None and not parsed.test:
+        msg = "'output' is required unless using --test"
+        parser.error(msg)
+    return parsed
+
+
+def setup_logging(*, debug: bool = False) -> None:
+    """Set up logging."""
+    level = logging.DEBUG if debug else logging.INFO
+    format_ = "%(levelname)s:%(name)s:%(asctime)s:" if debug else ""
+    format_ += "%(message)s"
+    logging.basicConfig(level=level, format=format_)
 
 
 if __name__ == "__main__":
-    raise SystemExit(_main())
+    raise SystemExit(main())

--- a/local/bin/reference.py
+++ b/local/bin/reference.py
@@ -52,8 +52,11 @@ def _main() -> int:
     elif command("match"):
         function = all
 
+    def absolute(path: str) -> str:
+        return str(REFERENCE_REPOSITORY.joinpath(path).absolute())
+
     query = [i.lower() for i in argv[2:]]
-    print("\n".join(search(query, function)) if function else __doc__)
+    print("\n".join(map(absolute, search(query, function))) if function else __doc__)
     return 0
 
 


### PR DESCRIPTION
- **receipt.py: add an initial version**
- **receipt.py: add options parsing and PDF output**
- **receipt.py: add JPEG2000 compression**
- **receipt.py: launch google-chrome**
- **receipt.py: make compression ratio configurable**
- **receipt.py: avoid automatic deskew and crop if -x specified**
- **receipt.py: include a border in the cropped output**
- **reference.py: output absolute paths**
- **adf: document centre aligned input**
- **adf: add a landscape example to help**
