### PR TITLE
Improve scanning tools

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,6 +26,7 @@ jobs:
         with: { persist-credentials: false }
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with: { enable-cache: false }
+      - run: sudo apt-get update && sudo apt-get --yes install python3-sane
       - run: ./noxfile.py
   renovate-config-validator:
     needs: smoke

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,7 +26,9 @@ jobs:
         with: { persist-credentials: false }
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with: { enable-cache: false }
-      - run: sudo apt-get update && sudo apt-get --yes install python3-sane
+      - run: >
+          sudo apt-get update
+          && sudo apt-get install --yes --no-install-recommends python3-sane
       - run: ./noxfile.py
   renovate-config-validator:
     needs: smoke

--- a/bin/check_each_path_is_in_file_contents.py
+++ b/bin/check_each_path_is_in_file_contents.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Check that each file contains its filename."""
 
 # bin/check_each_path_is_in_file_contents.py

--- a/bin/install.py
+++ b/bin/install.py
@@ -42,6 +42,7 @@ SPECIFICATIONS: list[tuple[str] | tuple[str, str]] = [
     ("~/.local/bin/gtree",),
     ("~/.local/bin/jpeg2000.py",),
     ("~/.local/bin/keep.py",),
+    ("~/.local/bin/landscape.py",),
     ("~/.local/bin/lint-all",),
     ("~/.local/bin/mvh1", "local/bin/mvh1.py"),
     ("~/.local/bin/mvslugify",),

--- a/bin/install.py
+++ b/bin/install.py
@@ -40,6 +40,7 @@ SPECIFICATIONS: list[tuple[str] | tuple[str, str]] = [
     ("~/.local/bin/create-dot-sha256.sh",),
     ("~/.local/bin/from.py",),
     ("~/.local/bin/gtree",),
+    ("~/.local/bin/jpeg2000.py",),
     ("~/.local/bin/keep.py",),
     ("~/.local/bin/lint-all",),
     ("~/.local/bin/mvh1", "local/bin/mvh1.py"),

--- a/local/bin/jpeg2000.py
+++ b/local/bin/jpeg2000.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env -S uv run --script
+"""Convert PNM files to JPEG 2000 images in a PDF."""
+
+# /// script
+# dependencies = [
+#   "img2pdf",
+#   "pillow",
+# ]
+# requires-python = ">=3.13"
+# ///
+
+# local/bin/jpeg2000.py
+# Copyright 2026 Keith Maxwell
+# SPDX-License-Identifier: MPL-2.0
+
+import logging
+from argparse import ArgumentParser, Namespace, RawDescriptionHelpFormatter
+from doctest import testmod
+from io import BytesIO
+from pathlib import Path
+from stat import S_IXUSR
+from subprocess import DEVNULL, Popen
+
+import img2pdf
+from PIL import Image
+
+DPI = 300
+VIEWER = Path("/usr/bin/google-chrome-stable")
+
+logger = logging.getLogger(__name__)
+
+
+def _main(_args: list[str] | None = None) -> int:
+    args = parse_args(_args)
+
+    setup_logging(debug=args.debug)
+    logger.debug("command line arguments: %s", args)
+
+    if args.test:
+        results = testmod()
+        logger.info("Test results: %s", results)
+        return max(0, min(results.failed, 1))
+    paths = list(Path().glob("*.pbm"))
+    images = [_convert(Image.open(i), args.compression) for i in paths]
+
+    img2pdf.default_dpi = DPI
+    with args.output.open("wb") as outputstream:
+        img2pdf.convert(images, outputstream=outputstream)
+
+    size = args.output.stat().st_size
+    logger.info("Wrote %s bytes to %s.", f"{size:,}", args.output)
+
+    if VIEWER.is_file() and VIEWER.stat().st_mode & S_IXUSR:
+        cmd = (VIEWER, args.output.absolute())
+        Popen(cmd, stdout=DEVNULL, stderr=DEVNULL)
+
+    return 0
+
+
+def _convert(img: Image.Image, compression: int) -> BytesIO:
+    result = BytesIO()
+    img.save(result, format="JPEG2000", quality_layers=[compression])
+    result.seek(0)
+    return result
+
+
+def parse_args(args: list[str] | None) -> Namespace:
+    """Parse command line arguments.
+
+    Supports --compression:
+
+    >>> parse_args(['example.pdf']).output
+    PosixPath('example.pdf')
+
+    Supports --compression:
+
+    >>> parse_args(['example.pdf']).compression
+    20
+    >>> parse_args(['example.pdf', '--compression=40']).compression
+    40
+
+    Supports --test which defaults off:
+
+    >>> parse_args(['example.pdf']).test
+    False
+    >>> parse_args(['example.pdf', '--test']).test
+    True
+
+    Supports --debug which defaults off:
+
+    >>> parse_args(['example.pdf']).debug
+    False
+    >>> parse_args(['example.pdf', '--debug']).debug
+    True
+
+    """
+    parser = ArgumentParser(
+        description=__doc__,
+        formatter_class=RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "output",
+        nargs="?",
+        help="output file name",
+        type=Path,
+    )
+    parser.add_argument(
+        "--compression",
+        default=20,
+        type=int,
+        help="approximate rate of size reduction.",
+    )
+    parser.add_argument(
+        "--test",
+        action="store_true",
+        help="run doctest against this file.",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="show debug logging.",
+    )
+    parsed = parser.parse_args(args)
+    if parsed.output is None and not parsed.test:
+        msg = "'output' is required unless using --test"
+        parser.error(msg)
+    return parsed
+
+
+def setup_logging(*, debug: bool = False) -> None:
+    """Set up logging."""
+    level = logging.DEBUG if debug else logging.INFO
+    format_ = "%(levelname)s:%(name)s:%(asctime)s:" if debug else ""
+    format_ += "%(message)s"
+    logging.basicConfig(level=level, format=format_)
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/local/bin/landscape.py
+++ b/local/bin/landscape.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python
+"""Scan A4 pages in landscape.
+
+Relies upon the system package manager to install python-sane. Configure ALE
+with:
+
+let g:ale_python_pyright_config={'python':{'pythonPath':'/usr/bin/python3.12'}}
+
+"""
+
+from os import environ
+from pathlib import Path
+
+import sane
+
+# /// script
+# dependencies = ["python-sane"]
+# requires-python = ">=3.12"
+# ///
+
+# local/bin/landscape.py
+# Copyright 2026 Keith Maxwell
+# SPDX-License-Identifier: MPL-2.0
+
+environ["SANE_CONFIG_DIR"] = str(Path("~/.config/adf").expanduser())
+
+MODEL = ("Brother", "ADS-1200", "USB scanner")
+MODE = "True Gray"
+SOURCE = "Automatic Document Feeder(center aligned,Duplex)"
+RESOLUTION = 300
+A4 = (210, 297)
+
+
+def _main() -> int:
+    sane.init()
+    devices = sane.get_devices(localOnly=True)
+    if devices[0][1:] != MODEL:
+        return 1
+
+    dev = sane.open(devices[0][0])
+
+    dev.mode = MODE
+    dev.br_x, dev.br_y = A4
+    dev.source = SOURCE
+    dev.resolution = 300
+
+    dev.start()
+    imgs = list(dev.multi_scan())
+    dev.close()
+    sane.exit()
+
+    for page, img in enumerate(imgs, start=1):
+        degrees = -90 if page % 2 == 1 else 90
+        filename = f"adf.{page:04}.pbm"
+        img.rotate(degrees, expand=True).save(filename)
+        print(filename)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/local/bin/landscape.py
+++ b/local/bin/landscape.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 """Scan A4 pages in landscape.
 
 Relies upon the system package manager to install python-sane. Configure ALE

--- a/local/bin/receipt.py
+++ b/local/bin/receipt.py
@@ -75,14 +75,18 @@ def main(_args: list[str] | None = None) -> int:
             "--source=Automatic Document Feeder(center aligned)",
             *args.options,
         )
-        result = run(cmd, capture_output=True, check=True, env=env)
+        result = run(cmd, capture_output=True, check=False, env=env)
         logger.debug("returncode %s from `%s`", result.returncode, join(cmd))
-        scan = result.stdout
+        scan = result.stdout if result.returncode == 0 else b""
+        if result.stderr:
+            logger.error(result.stderr.decode().strip())
 
-    img = cv2.imdecode(np.frombuffer(scan, np.uint8), cv2.IMREAD_GRAYSCALE)
+    img = None
+    if scan:
+        img = cv2.imdecode(np.frombuffer(scan, np.uint8), cv2.IMREAD_GRAYSCALE)
     if img is None:
-        msg = "Failed to read image from scanner."
-        raise RuntimeError(msg)
+        logger.error("Failed to read image from scanner.")
+        return 1
 
     if args.keep and not CACHE.is_file():
         write("cache.pnm", img)

--- a/local/bin/receipt.py
+++ b/local/bin/receipt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv run
+#!/usr/bin/env -S uv run --script
 """Scan a receipt, process it and save as a PDF.
 
 Process means:

--- a/local/bin/venv.py
+++ b/local/bin/venv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Check and optionally set up a virutal environment.
 
 Based on inline script metadata. Requires uv. Does not support version

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv run
+#!/usr/bin/env -S uv run --script
 # noxfile.py
 # Copyright 2025 Keith Maxwell
 # SPDX-License-Identifier: MPL-2.0

--- a/noxfile.py
+++ b/noxfile.py
@@ -104,8 +104,12 @@ def doctest(session: Session) -> None:
 def pyright(session: Session) -> None:
     """Run pyright on all Python files."""
     for i in _python_files(session):
-        session.run("local/bin/venv.py", "--create", "--quiet", i, external=True)
-        cmd = "npm exec --yes pyright -- --pythonpath=.venv/bin/python"
+        shebang = Path(i).read_text().splitlines()[0]
+        if shebang == "#!/usr/bin/env python3":
+            cmd = "npm exec --yes pyright -- --pythonpath=/usr/bin/python3"
+        else:
+            session.run("local/bin/venv.py", "--create", "--quiet", i, external=True)
+            cmd = "npm exec --yes pyright -- --pythonpath=.venv/bin/python"
         session.run(*cmd.split(" "), i, external=True)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -79,8 +79,12 @@ def black(session: Session) -> None:
 @nox.session(python=False)
 def vendor(session: Session) -> None:
     """Run bin/vendor.toml and check for changes."""
-    for cmd in ["bin/vendor.toml", "git diff --exit-code"]:
-        session.run(*cmd.split(" "))
+    for cmd in [
+        ["bin/vendor.toml"],
+        ["git", "clean", "-f", "*.dist-info/*"],
+        ["git", "diff", "--exit-code"],
+    ]:
+        session.run(*cmd)
 
 
 @nox.session(python=False)


### PR DESCRIPTION
- **Display stderr if scanimage fails inside receipt.py**
- **Add a script to encode as JPEG 2000 images in a PDF**
- **Add a script for scanning landscape**
- **Skip venv.py if using /usr/bin/python**
- **Adopt a standard shebang line for system Python**
- **Clean up dist-info when vendoring**
