### PR TITLE
Tweak scanning scripts

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,7 +24,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with: { persist-credentials: false }
-      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8
+      # yamllint disable-line rule:line-length
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with: { enable-cache: false }
       - run: >
           sudo apt-get update

--- a/bin/check_each_path_is_in_file_contents.py
+++ b/bin/check_each_path_is_in_file_contents.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 """Check that each file contains its filename."""
 
 # bin/check_each_path_is_in_file_contents.py

--- a/bin/install.py
+++ b/bin/install.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 """Install symbolic links to files in this repository.
 
 Maintain compatibility with the system Python on Debian stable. Today that is

--- a/bin/unrecognised.py
+++ b/bin/unrecognised.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 """Check for unrecognised files in ~/.local/bin/."""
 
 # /// script

--- a/bin/update.py
+++ b/bin/update.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 """Upate the checksums in a TOML file."""
 
 # bin/update.py

--- a/local/bin/jpeg2000.py
+++ b/local/bin/jpeg2000.py
@@ -48,7 +48,7 @@ def _main(_args: list[str] | None = None) -> int:
         img2pdf.convert(images, outputstream=outputstream)
 
     size = args.output.stat().st_size
-    logger.info("Wrote %s bytes to %s.", f"{size:,}", args.output)
+    logger.info("Wrote %s bytes to %s", f"{size:,}", args.output)
 
     if VIEWER.is_file() and VIEWER.stat().st_mode & S_IXUSR:
         cmd = (VIEWER, args.output.absolute())

--- a/local/bin/jpeg2000.py
+++ b/local/bin/jpeg2000.py
@@ -41,7 +41,7 @@ def _main(_args: list[str] | None = None) -> int:
         results = testmod()
         logger.info("Test results: %s", results)
         return max(0, min(results.failed, 1))
-    paths = list(Path().glob("*.p[nb]m"))
+    paths = sorted(Path().glob("*.p[nb]m"))
     images = [_convert(Image.open(i), args.compression) for i in paths]
 
     img2pdf.default_dpi = DPI

--- a/local/bin/jpeg2000.py
+++ b/local/bin/jpeg2000.py
@@ -113,12 +113,12 @@ def parse_args(args: list[str] | None) -> Namespace:
     parser.add_argument(
         "--test",
         action="store_true",
-        help="run doctest against this file.",
+        help="run doctest against this file",
     )
     parser.add_argument(
         "--debug",
         action="store_true",
-        help="show debug logging.",
+        help="show debug logging",
     )
     parsed = parser.parse_args(args)
     if parsed.output is None and not parsed.test:

--- a/local/bin/jpeg2000.py
+++ b/local/bin/jpeg2000.py
@@ -41,7 +41,7 @@ def _main(_args: list[str] | None = None) -> int:
         results = testmod()
         logger.info("Test results: %s", results)
         return max(0, min(results.failed, 1))
-    paths = list(Path().glob("*.pbm"))
+    paths = list(Path().glob("*.p[nb]m"))
     images = [_convert(Image.open(i), args.compression) for i in paths]
 
     img2pdf.default_dpi = DPI

--- a/local/bin/jpeg2000.py
+++ b/local/bin/jpeg2000.py
@@ -26,6 +26,7 @@ from PIL import Image
 
 DPI = 300
 VIEWER = Path("/usr/bin/google-chrome-stable")
+DEFAULT_COMPRESSION = 20
 
 logger = logging.getLogger(__name__)
 
@@ -74,8 +75,8 @@ def parse_args(args: list[str] | None) -> Namespace:
 
     Supports --compression:
 
-    >>> parse_args(['example.pdf']).compression
-    20
+    >>> parse_args(['example.pdf']).compression == DEFAULT_COMPRESSION
+    True
     >>> parse_args(['example.pdf', '--compression=40']).compression
     40
 
@@ -106,9 +107,9 @@ def parse_args(args: list[str] | None) -> Namespace:
     )
     parser.add_argument(
         "--compression",
-        default=20,
+        default=DEFAULT_COMPRESSION,
         type=int,
-        help="approximate rate of size reduction.",
+        help=f"approximate rate of size reduction (default: {DEFAULT_COMPRESSION})",
     )
     parser.add_argument(
         "--test",

--- a/local/bin/landscape.py
+++ b/local/bin/landscape.py
@@ -8,6 +8,9 @@ let g:ale_python_pyright_config={'python':{'pythonPath':'/usr/bin/python3.12'}}
 
 """
 
+import logging
+from argparse import ArgumentParser, Namespace
+from doctest import testmod
 from os import environ
 from pathlib import Path
 
@@ -30,17 +33,28 @@ SOURCE = "Automatic Document Feeder(center aligned,Duplex)"
 RESOLUTION = 300
 A4 = (210, 297)
 
+logger = logging.getLogger(__name__)
 
-def _main() -> int:
+
+def _main(_args: list[str] | None = None) -> int:
+    args = parse_args(_args)
+
+    setup_logging(debug=args.debug)
+    logger.debug("command line arguments: %s", args)
+
+    if args.test:
+        results = testmod()
+        logger.info("test results: %s", results)
+        return max(0, min(results.failed, 1))
+
     sane.init()
-    devices = sane.get_devices(localOnly=True)
-    if devices[0][1:] != MODEL:
-        return 1
+    device = sane.get_devices(localOnly=True)[0]
+    dev = sane.open(device[0])
+    logger.debug("using scanner %s", device)
 
-    dev = sane.open(devices[0][0])
-
+    dev.br_x = args.x
+    dev.br_y = args.y
     dev.mode = MODE
-    dev.br_x, dev.br_y = A4
     dev.source = SOURCE
     dev.resolution = 300
 
@@ -55,6 +69,63 @@ def _main() -> int:
         img.rotate(degrees, expand=True).save(filename)
         print(filename)
     return 0
+
+
+def parse_args(args: list[str] | None) -> Namespace:
+    """Parse command line arguments.
+
+    Check that -x and -y are supported and default to A4:
+
+    >>> args = parse_args([])
+    >>> args.x, args.y
+    (210, 297)
+    >>> args = parse_args(["-x100", "-y200"])
+    >>> args.x, args.y
+    (100, 200)
+
+    Check that setting --debug and --test are supported and default off
+
+    >>> args = parse_args([])
+    >>> args.debug, args.test
+    (False, False)
+    >>> args = parse_args(['--debug', '--test'])
+    >>> args.debug, args.test
+    (True, True)
+
+
+    """
+    parser = ArgumentParser()
+    parser.add_argument(
+        "-x",
+        default=A4[0],
+        type=int,
+        help=f"height in mm (default: {A4[0]})",
+    )
+    parser.add_argument(
+        "-y",
+        default=A4[1],
+        type=int,
+        help=f"width in mm (default: {A4[1]})",
+    )
+    parser.add_argument(
+        "--test",
+        action="store_true",
+        help="run doctest against this file.",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="show debug logging.",
+    )
+    return parser.parse_args(args)
+
+
+def setup_logging(*, debug: bool = False) -> None:
+    """Set up logging."""
+    level = logging.DEBUG if debug else logging.INFO
+    format_ = "%(levelname)s:%(name)s:%(asctime)s:" if debug else ""
+    format_ += "%(message)s"
+    logging.basicConfig(level=level, format=format_)
 
 
 if __name__ == "__main__":

--- a/local/bin/landscape.py
+++ b/local/bin/landscape.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 """Scan A4 pages in landscape.
 
 Relies upon the system package manager to install python-sane. Configure ALE

--- a/local/bin/pdf-information.py
+++ b/local/bin/pdf-information.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 """Show information about PDFs stored in git.
 
 Requires git and optionally pdfinfo from poppler

--- a/local/bin/reference.py
+++ b/local/bin/reference.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 """Helper script for reference PDFs.
 
 reference.py find word [word…]

--- a/local/bin/repositories.py
+++ b/local/bin/repositories.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 """Find everything called .git in $HOME.
 
 - SKIP certain directories.

--- a/local/bin/venv.py
+++ b/local/bin/venv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 """Check and optionally set up a virutal environment.
 
 Based on inline script metadata. Requires uv. Does not support version

--- a/noxfile.py
+++ b/noxfile.py
@@ -23,6 +23,7 @@ from nox.sessions import Session
 nox.options.default_venv_backend = "uv"
 
 VENV = Path(".venv").absolute()
+PYTHON3 = "/usr/bin/python3"
 
 
 @nox.session(python=False)
@@ -93,8 +94,9 @@ def doctest(session: Session) -> None:
     files = _files(session, ">>> ")
     files.remove("noxfile.py")
     for i in files:
-        python = "python"
-        if "/// script" in Path(i).read_text():
+        if shebang(i) == PYTHON3:
+            python = PYTHON3
+        else:
             session.run("local/bin/venv.py", "--create", "--quiet", i)
             python = ".venv/bin/python"
         session.run(python, "-m", "doctest", "-v", i)
@@ -104,9 +106,8 @@ def doctest(session: Session) -> None:
 def pyright(session: Session) -> None:
     """Run pyright on all Python files."""
     for i in _python_files(session):
-        shebang = Path(i).read_text().splitlines()[0]
-        if shebang == "#!/usr/bin/env python3":
-            cmd = "npm exec --yes pyright -- --pythonpath=/usr/bin/python3"
+        if shebang(i) == PYTHON3:
+            cmd = f"npm exec --yes pyright -- --pythonpath={PYTHON3}"
         else:
             session.run("local/bin/venv.py", "--create", "--quiet", i, external=True)
             cmd = "npm exec --yes pyright -- --pythonpath=.venv/bin/python"
@@ -130,6 +131,11 @@ def _python_files(session: Session) -> list[str]:
     Assumes all Python files include the string "requires-python".
     """
     return _files(session, "requires-python")
+
+
+def shebang(script: str) -> str:
+    """Return the first line of a script after #!."""
+    return Path(script).read_text().splitlines()[0].removeprefix("#!")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- jpeg2000.py: Remove the full stop so that clicking in Ghostty works
- jpeg2000.py: remove full stops in --help
- jpeg2000.py: show default compression in --help
- jpeg2000.py: work with .pbm and .pnm
- jpeg2000.py: sort input file names
- landscape.py: handle command line arguments and add logging
- Use /usr/bin/python3 as standard shebang line
- Use shebang line to identify Python for doctests
