### PR TITLE
Set the output format in ~/.local/bin/adf

### DIFF
--- a/local/bin/adf
+++ b/local/bin/adf
@@ -116,6 +116,7 @@ acquire() {
 			_acquire \
 				"--mode=Black & White" \
 				"--source=Automatic Document Feeder(center aligned$duplex)" \
+				--format=pnm \
 				--batch=adf.%04d.pbm \
 				"$@"
 			;;


### PR DESCRIPTION
Before this change:

    % adf full test.pdf
    Output format is not set, using pnm as a default.
    scanimage: rounded value of br-x from 210 to 209.981
    scanimage: rounded value of br-y from 297 to 296.973
    Scanning infinity pages, incrementing…

After this change:

    % adf full test.pdf
    scanimage: rounded value of br-x from 210 to 209.981
    scanimage: rounded value of br-y from 297 to 296.973
    Scanning infinity pages, incrementing…
